### PR TITLE
Include error details in CTRF JSON report

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
-    "test": "mocha",
+    "test": "mocha ./tests",
     "lint": "eslint . --ext .ts --fix",
     "lint-check": "eslint . --ext .ts",
     "format": "prettier --write .",

--- a/src/generate-report.ts
+++ b/src/generate-report.ts
@@ -97,7 +97,9 @@ class GenerateCtrfReport extends reporters.Base {
 
     runner
       .on('start', this.handleStart.bind(this))
-      .on('test end', this.handleTestEnd.bind(this))
+      .on('pass', this.handleTestEnd.bind(this))
+      .on('pending', this.handleTestEnd.bind(this))
+      .on('fail', this.handleTestEnd.bind(this))
       .on('end', this.handleEnd.bind(this))
   }
 
@@ -109,7 +111,10 @@ class GenerateCtrfReport extends reporters.Base {
     }
   }
 
-  handleTestEnd(test: Mocha.Test): void {
+  handleTestEnd(test: Mocha.Test, err?: Error): void {
+    if (err != null) {
+      test.err = err
+    }
     this.updateCtrfTestResultsFromTest(test, this.ctrfReport)
     this.updateCtrfTotalsFromTest(test, this.ctrfReport)
   }

--- a/tests/hooks.spec.js
+++ b/tests/hooks.spec.js
@@ -1,0 +1,21 @@
+describe('Hooks-after each', () => {
+    describe('Hook should pass', () => {
+        afterEach(() => {
+            console.log('This is an afterEach hook');
+        });
+
+        it('Test 1', () => {});
+
+        it('Test 2', (done) => {
+            done(new Error('This is an error in Test 2'));
+        });
+    });
+
+    describe('Hook should fail', () => {
+        afterEach(() => {
+            throw new Error('This is an error in afterEach hook');
+        });
+
+        it('Test 1', () => { });
+    });
+});

--- a/tests/tests.spec.js
+++ b/tests/tests.spec.js
@@ -1,0 +1,9 @@
+describe('Tests', function() {
+    it('should pass', function() { });
+
+    it('should fail', function(done) {
+        done(new Error('This is an error in Test 2'));
+    });
+
+    it.skip('should be skipped', function() { });
+});


### PR DESCRIPTION
- Added methods to handle test start, end, and individual test results.
- Implemented methods to update test results and summary in the CTRF report.

Ref: https://github.com/ctrf-io/mocha-ctrf-json-reporter/issues/12