### PR TITLE
Add skiped tests to summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,9 @@ Alternatively, you can pass the reporter options via the command line when runni
 ```bash
 npx mocha --reporter mocha-ctrf-json-reporter --reporter-options "outputFile=custom-name.json,outputDir=custom-directory,appName=MyApp,appVersion=1.0.0"
 ```
+
 ### Results Report
+
 Results JSON filename can contain `[hash]`, e.g. `./path_to_your/test-results.[hash].json`. `[hash]` is replaced by MD5 hash of test results JSON. This enables support of parallel execution of multiple `mocha-ctrf-json-reporter`'s writing test results in separate files.
 
 ## Test Object Properties

--- a/src/generate-report.ts
+++ b/src/generate-report.ts
@@ -193,7 +193,11 @@ class GenerateCtrfReport extends reporters.Base {
   }
 
   private updateCtrfTotalsFromTest(
-    test: Mocha.Test,
+    test:
+      | Mocha.Test
+      | {
+          state?: 'failed' | 'passed' | 'pending' | 'skipped' | undefined
+        },
     ctrfReport: CtrfReport
   ): void {
     ctrfReport.results.summary.tests++
@@ -207,6 +211,9 @@ class GenerateCtrfReport extends reporters.Base {
         break
       case 'pending':
         ctrfReport.results.summary.pending++
+        break
+      case 'skipped':
+        ctrfReport.results.summary.skipped++
         break
       default:
         ctrfReport.results.summary.other++

--- a/tests/tests.spec.js
+++ b/tests/tests.spec.js
@@ -5,5 +5,23 @@ describe('Tests', function () {
     done(new Error('This is an error in Test 2'))
   })
 
-  it.skip('should be skipped', function () {})
+  it.skip('should be skipped', function () {}).describe(
+    'Will be marked as pending.'
+  )
+
+  context('Tests context', () => {
+    beforeEach(() => {
+      this.nonExistentProperty.AnotherOneMissing = 123456
+    })
+
+    it('should pass', function () {}).describe('Will be marked as skipped.')
+
+    it('should fail', function (done) {
+      done(new Error('This is an error in Test 4'))
+    }).describe('Will be marked as skipped.')
+
+    it.skip('should be skipped', function () {}).describe(
+      'Will be marked as skipped.'
+    )
+  })
 })


### PR DESCRIPTION
`mochawesome` reports "skipped" tests wich don't count neither as "passed" or "failed". 
It's not described in `mocha` types that "skipped" is an actual test status.

This PR is about mapping test with that state inton the summary.

Check here, the "skipped" is described:
https://docs.sorry-cypress.dev/concepts/test-status