### PR TITLE
Add line number to test failure reports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "ctrf": "^0.2.0",
-        "md5": "^2.3.0"
+        "md5": "^2.3.0",
+        "stacktrace-parser": "^0.1.11"
       },
       "devDependencies": {
         "@types/md5": "^2.3.6",
@@ -4181,6 +4182,18 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/stacktrace-parser": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.11.tgz",
+      "integrity": "sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.7.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -4513,6 +4526,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz",
+      "integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/typed-array-buffer": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "mocha ./tests",
+    "test": "mocha ./tests --reporter dist/index.js",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",
     "format": "prettier --write .",
@@ -65,6 +65,7 @@
   },
   "dependencies": {
     "ctrf": "^0.2.0",
+    "stacktrace-parser": "^0.1.11",
     "md5": "^2.3.0"
   }
 }

--- a/src/generate-report.ts
+++ b/src/generate-report.ts
@@ -14,6 +14,7 @@ import {
   createTestRuntime,
   type RuntimeMessage,
 } from './runtime'
+import { parse as parseStack } from 'stacktrace-parser'
 
 // Local overrides to keep backward-compatible string suite (canonical is string[])
 // TODO(v1): align suite to string[] and remove this override
@@ -213,8 +214,7 @@ class GenerateCtrfReport extends reporters.Base {
 
     if (testCase.state === 'failed' && testCase.err != null) {
       const failureDetails = this.extractFailureDetails(testCase)
-      test.message = failureDetails.message
-      test.trace = failureDetails.trace
+      Object.assign(test, failureDetails)
     }
 
     // Apply any pending runtime messages (extra data) to this test
@@ -392,6 +392,11 @@ class GenerateCtrfReport extends reporters.Base {
         failureDetails.message = `${testResult.err.name} ${testResult.err.message}`
       }
       if (testResult.err.stack !== undefined) {
+        const frames = parseStack(testResult.err.stack)
+        const frame = frames.find(
+          (f) => f.file && testResult.file?.endsWith(f.file)
+        )
+        failureDetails.line = frame?.lineNumber ?? undefined
         failureDetails.trace = testResult.err.stack
       }
       return failureDetails

--- a/tests/tests.spec.js
+++ b/tests/tests.spec.js
@@ -7,6 +7,10 @@ describe('Tests', function () {
 
   it.skip('should be skipped', function () {})
 
+  it('should fail', () => {
+    throw new Error('oh no!')
+  })
+
   context('Tests context', () => {
     beforeEach(function () {
       this.testProperty = 123456


### PR DESCRIPTION
Extracting this from the stack trace and including it in the CTRF data helps some test reporters, e.g. by providing a deep link to the point of failure.