### PR TITLE
chore: align Mocha reporter CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,17 +27,17 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '26'
           cache: npm
 
       - name: Install
         run: npm ci
 
       - name: Lint
-        run: npm run lint:check --if-present
+        run: npm run lint:check
 
       - name: Format check
-        run: npm run format:check --if-present
+        run: npm run format:check
 
   test-build:
     name: Test + Build (Node ${{ matrix.node }})
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['20', '22', '24']
+        node: ['20', '22', '24', '26']
 
     permissions:
       contents: read
@@ -66,7 +66,7 @@ jobs:
         run: npm ci
 
       - name: Test
-        run: npm test --if-present
+        run: npm test
 
       - name: Publish Test Report
         uses: ctrf-io/github-test-reporter@v1
@@ -78,13 +78,13 @@ jobs:
           flaky-rate-report: true
           previous-results-report: true
           upload-artifact: true
-          artifact-name: ctrf-mocha-test-report-node-${{ matrix.node }}
+          artifact-name: ctrf-test-report-node-${{ matrix.node }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: always() && hashFiles('ctrf/*.json') != ''
 
       - name: Build
-        run: npm run build --if-present
+        run: npm run build
 
   security:
     name: Security (deps audit)
@@ -98,7 +98,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '26'
           cache: npm
 
       - name: Install

--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
 	},
 	"scripts": {
 		"build": "tsc",
-		"test": "mocha ./tests",
+		"test": "npm run build && mocha --reporter ./dist/index.js ./tests",
 		"lint": "biome lint --write . --unsafe",
 		"lint:check": "biome lint .",
 		"format": "biome format --write .",
 		"format:check": "biome format .",
-		"all": "npm run lint && npm run format:check && npm run build && npm run check",
+		"all": "npm run lint:check && npm run format:check && npm run test && npm run build",
 		"check": "biome check ."
 	},
 	"repository": {


### PR DESCRIPTION
## Summary
- keep Mocha as the native test runner
- include tests in npm run all
- run this package reporter during tests for CTRF output
- align main workflow with the standard Node 20/22/24/26 CI shape

## Verification
- npm run all
- npm audit --omit=dev